### PR TITLE
Add RCT_EXPORT_MODULE

### DIFF
--- a/RCTFBLogin/RCTFBLoginManager.m
+++ b/RCTFBLogin/RCTFBLoginManager.m
@@ -26,6 +26,7 @@
 }
 
 RCT_EXPORT_VIEW_PROPERTY(permissions, NSStringArray);
+RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport {
   return @{


### PR DESCRIPTION
Missing RCT_EXPORT_MODULE in RCTFBLoginManager class.
Native Module now require RCT_EXPORT_MODULE() macro (https://facebook.github.io/react-native/docs/nativemodulesios.html)