### PR TITLE
fix compability with react native 0.13.1

### DIFF
--- a/RCTFBLogin/RCTFBLogin.m
+++ b/RCTFBLogin/RCTFBLogin.m
@@ -33,8 +33,8 @@
 - (void)layoutSubviews
 {
     [super layoutSubviews];
-    RCTAssert(self.subviews.count == 1, @"we should only have exactly one subview");
-    RCTAssert([self.subviews lastObject] == _loginButton, @"our only subview should be a fbsdkloginbutton");
+    // RCTAssert(self.subviews.count == 1, @"we should only have exactly one subview");
+    // RCTAssert([self.subviews lastObject] == _loginButton, @"our only subview should be a fbsdkloginbutton");
     _loginButton.frame = _loginButton.bounds;
 }
 


### PR DESCRIPTION
`RCTAssert` functions cause linker error `"__RCTAssertFormat", referenced from...`