### PR TITLE
Depend to `react-native` as a peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/magus/react-native-facebook-login/issues"
   },
   "homepage": "https://github.com/magus/react-native-facebook-login",
-  "dependencies": {
-    "react-native": "^0.6.0"
+  "peerDependencies": {
+    "react-native": ">=0.6.0"
   }
 }


### PR DESCRIPTION
I'm proposing two changes to how `react-native` dependencies should be handled:

### Consider `react-native` a peer dependency. 

This library is a plugin, it does not *make use* of React native, it adds functionality to it. As such there will never be a project that uses `react-native-facebook-login`, but does not already import React native. 

Defining `react-native` as a dependency can cause issues when the relaxed semver requirement allows different versions of the framework do be installed by different plugins, and the dependent project itself. This just broke my build when upgrading to `react-native` 0.6.0, and prevented me from using 0.6.0-rc without forking `react-native-facebook-login`. See: https://github.com/facebook/react-native/issues/1606#issuecomment-113113816

### Consider `react-native` to be always forwards compatible. 

Facebook has now moved to a two week release cycle, where they release a new minor version every two weeks and simultaneously release a release candidate of the next minor version. 

While there may be breaking changes in the future, arbitrarily preventing users of `react-native-facebook-login` to upgrade is a bigger limitation.