### PR TITLE
Fix for React Native 0.8

### DIFF
--- a/FBLogin.ios.js
+++ b/FBLogin.ios.js
@@ -2,10 +2,9 @@ var React = require('react-native');
 var {
   StyleSheet,
   PropTypes,
-  NativeModules
+  NativeModules,
+  requireNativeComponent
 } = React;
-var createReactNativeComponentClass = require('react-native/Libraries/ReactNative/createReactNativeComponentClass');
-var ReactNativeViewAttributes = require('react-native/Libraries/ReactNative/ReactNativeViewAttributes');
 var LayoutPropTypes = require('react-native/Libraries/StyleSheet/LayoutPropTypes');
 var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
 var NativeMethodsMixin = require('react-native/Libraries/ReactIOS/NativeMethodsMixin');
@@ -90,13 +89,7 @@ var FBLogin = React.createClass({
   },
 });
 
-var RCTFBLogin = createReactNativeComponentClass({
-  validAttributes: {
-    ...ReactNativeViewAttributes.UIView,
-    permissions: true,
-  },
-  uiViewClassName: 'RCTFBLogin',
-});
+var RCTFBLogin = requireNativeComponent('RCTFBLogin', FBLogin);
 
 var styles = StyleSheet.create({
   base: {

--- a/FBLogin.ios.js
+++ b/FBLogin.ios.js
@@ -1,13 +1,18 @@
-var React = require('React');
-var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var StyleSheet = require('StyleSheet');
-var createReactNativeComponentClass = require('createReactNativeComponentClass');
-var PropTypes = require('ReactPropTypes');
-var LayoutPropTypes = require('LayoutPropTypes');
-var StyleSheetPropType = require('StyleSheetPropType');
-var NativeMethodsMixin = require('NativeMethodsMixin');
-var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
-var FBLoginManager = require('NativeModules').FBLoginManager;
+var React = require('react-native');
+var {
+  StyleSheet,
+  PropTypes,
+  NativeModules
+} = React;
+var createReactNativeComponentClass = require('react-native/Libraries/ReactNative/createReactNativeComponentClass');
+var ReactNativeViewAttributes = require('react-native/Libraries/ReactNative/ReactNativeViewAttributes');
+var LayoutPropTypes = require('react-native/Libraries/StyleSheet/LayoutPropTypes');
+var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
+var NativeMethodsMixin = require('react-native/Libraries/ReactIOS/NativeMethodsMixin');
+var RCTDeviceEventEmitter = require('react-native/Libraries/Device/RCTDeviceEventEmitter');
+var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
+
+var { FBLoginManager } = NativeModules;
 
 var FBLogin = React.createClass({
   statics: {


### PR DESCRIPTION
Fixes warnings which would appear like:
```
Unable to resolve module React from [project_path]/node_modules/react-native-facebook-login/FBLogin.ios.js
```

Also using the new [`requireNativeComponent` function](https://github.com/facebook/react-native/blob/f1bd1cbc942662e93035d16aebd8b5c311298cee/Libraries/ReactIOS/requireNativeComponent.js) as described on https://facebook.github.io/react-native/docs/native-components-ios.html