### PR TITLE
Use correct react native packager `require` statements

### DIFF
--- a/FBLogin.ios.js
+++ b/FBLogin.ios.js
@@ -5,11 +5,11 @@ var {
   NativeModules,
   requireNativeComponent
 } = React;
-var LayoutPropTypes = require('react-native/Libraries/StyleSheet/LayoutPropTypes');
-var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
-var NativeMethodsMixin = require('react-native/Libraries/ReactIOS/NativeMethodsMixin');
-var RCTDeviceEventEmitter = require('react-native/Libraries/Device/RCTDeviceEventEmitter');
-var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
+var LayoutPropTypes = require('LayoutPropTypes');
+var StyleSheetPropType = require('StyleSheetPropType');
+var NativeMethodsMixin = require('NativeMethodsMixin');
+var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+var StyleSheetPropType = require('StyleSheetPropType');
 
 var { FBLoginManager } = NativeModules;
 


### PR DESCRIPTION
Using [react-native-webpack-server](https://github.com/mjohnston/react-native-webpack-server), it turns out that, because [react native internal modules are set as 'externals' in the webpack config](https://github.com/mjohnston/react-native-webpack-server/blob/master/lib/getReactNativeExternals.js), there ends up being two instances of `RCTDeviceEventEmitter`: one created by the react native packager, and one created by webpack via `require('react-native/Libraries/Device/RCTDeviceEventEmitter')`. This results in `"FBLogin*"` events not being received by the proper `RCTDeviceEventEmitter` so FBLogin callbacks `onLogin`, `onLogout`, etc. weren't being called.

Reverting back to the react-native-style `require` statements fixes the problem since there's now only one `RCTDeviceEventEmitter` instance.