### PR TITLE
Add support for loginBehavior

### DIFF
--- a/FBLogin.ios.js
+++ b/FBLogin.ios.js
@@ -17,6 +17,12 @@ var FBLogin = React.createClass({
   statics: {
     Events: FBLoginManager.Events,
     LoginBehaviors: FBLoginManager.LoginBehaviors
+    /* Exported values for LoginBehavior
+     * Web: This is the default behavior, and indicates logging in through the native Facebook app may be used. The SDK may still use Safari instead.
+     * Browser: Attempts log in through the Safari or SFSafariViewController, if available
+     * Native: Attempts log in through the Facebook account currently signed in through the device Settings.
+     * SystemAccount: Attempts log in through a modal UIWebView pop up
+     */
   },
 
   propTypes: {

--- a/FBLogin.ios.js
+++ b/FBLogin.ios.js
@@ -16,6 +16,7 @@ var { FBLoginManager } = NativeModules;
 var FBLogin = React.createClass({
   statics: {
     Events: FBLoginManager.Events,
+    LoginBehaviors: FBLoginManager.LoginBehaviors
   },
 
   propTypes: {
@@ -28,6 +29,7 @@ var FBLogin = React.createClass({
     onError: PropTypes.func,
     onCancel: PropTypes.func,
     onPermissionsMissing: PropTypes.func,
+    loginBehavior: React.PropTypes.number
   },
 
   getInitialState: function(){

--- a/FBLogin.ios.js
+++ b/FBLogin.ios.js
@@ -35,7 +35,7 @@ var FBLogin = React.createClass({
     onError: PropTypes.func,
     onCancel: PropTypes.func,
     onPermissionsMissing: PropTypes.func,
-    loginBehavior: React.PropTypes.number
+    loginBehavior: React.PropTypes.number // default: Native
   },
 
   getInitialState: function(){

--- a/RCTFBLogin/RCTFBLogin.h
+++ b/RCTFBLogin/RCTFBLogin.h
@@ -3,6 +3,7 @@
 @interface RCTFBLogin : RCTView
 
 @property (nonatomic, assign) NSArray *permissions;
+@property (nonatomic, assign) NSNumber *loginBehavior;
 
 - (void)setDelegate:(id<FBSDKLoginButtonDelegate>)delegate;
 

--- a/RCTFBLogin/RCTFBLogin.m
+++ b/RCTFBLogin/RCTFBLogin.m
@@ -30,6 +30,11 @@
     _loginButton.readPermissions = permissions;
 }
 
+- (void)setLoginBehavior:(NSNumber *)loginBehavior
+{
+    _loginButton.loginBehavior = [loginBehavior intValue];
+}
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];

--- a/RCTFBLogin/RCTFBLoginManager.m
+++ b/RCTFBLogin/RCTFBLoginManager.m
@@ -31,6 +31,7 @@
 }
 
 RCT_EXPORT_VIEW_PROPERTY(permissions, NSStringArray);
+RCT_EXPORT_VIEW_PROPERTY(loginBehavior, NSNumber);
 RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport {
@@ -44,6 +45,12 @@ RCT_EXPORT_MODULE();
       @"PermissionsMissing": @"FBLoginPermissionsMissingEvent",
       @"LoginNotFound": @"FBLoginLoginNotFoundEvent"
     },
+    @"LoginBehaviors": @{
+      @"Web": [NSNumber numberWithInt:FBSDKLoginBehaviorWeb],
+      @"Browser": [NSNumber numberWithInt:FBSDKLoginBehaviorBrowser],
+      @"Native": [NSNumber numberWithInt:FBSDKLoginBehaviorNative],
+      @"SystemAccount": [NSNumber numberWithInt:FBSDKLoginBehaviorSystemAccount]
+    }
   };
 }
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ var Login = React.createClass({
 });
 ```
 
+You can change the login behavior by using the `loginBehavior` prop on the `FBLogin` component.  
+Acceptable property values are:
+
+* `FBLogin.LoginBehaviors.Web`: This is the default behavior, and indicates logging in through the native Facebook app may be used. The SDK may still use Safari instead.
+* `FBLogin.LoginBehaviors.Browser`: Attempts log in through the Safari or SFSafariViewController, if available
+* `FBLogin.LoginBehaviors.Native`: Attempts log in through the Facebook account currently signed in through the device Settings.
+* `FBLogin.LoginBehaviors.SystemAccount`: Attempts log in through a modal UIWebView pop up
+
+
 ## FBLoginManager
 Wraps features of the native iOS Facebook SDK `FBSDKLoginManager` interface.
 


### PR DESCRIPTION
Add support for setting the `loginBehavior` to any of the options specified in `FBSDKLoginBehavior` enum:
- `FBSDKLoginBehaviorWeb`
- `FBSDKLoginBehaviorBrowser`
- `FBSDKLoginBehaviorNative`
- `FBSDKLoginBehaviorSystemAccount`

by using the `loginBehavior` prop of `FBLogin` set to one of the values `Web`, `Browser`, `Native`, or `SystemAccount` from `FBLogin.LoginBehaviors`