### PR TITLE
setState called when component is unmounted

### DIFF
--- a/FBLogin.ios.js
+++ b/FBLogin.ios.js
@@ -80,6 +80,7 @@ var FBLogin = React.createClass({
   componentDidMount: function(){
     var _this = this;
     FBLoginManager.getCredentials(function(error, data){
+      if( !_this.isMounted() ) return;
       if (!error) {
         _this.setState({ credentials : data.credentials });
       } else {


### PR DESCRIPTION
Hi,

Thanks for the package.
In my use case I got the following error:
```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the FBLogin component.
```

Added a quick fix to check if component is mounted before calling ```setState```.
Please review & merge.