### PR TITLE
avoid multiple callback calls in RCTFBLoginManager

### DIFF
--- a/RCTFBLogin/RCTFBLoginManager.m
+++ b/RCTFBLogin/RCTFBLoginManager.m
@@ -192,7 +192,6 @@ RCT_EXPORT_METHOD(loginWithPermissions:(NSArray *)permissions callback:(RCTRespo
             @"declinedPermissions": decliendPermissions
           };
           [self fireEvent:@"PermissionsMissing" withData:permissionData];
-          callback(@[@"PermissionsMissing", permissionData]);
       }
     }
   }];


### PR DESCRIPTION
Hi,

`loginWithPermissions` currently triggers the callback twice if permissions are missing, which raises an error.

In case of missing permissions, this PR triggers the success callback (as the user is logged in) and simply fires the `PermissionsMissing` event.

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/magus/react-native-facebook-login/39)
<!-- Reviewable:end -->
