### PR TITLE
update README: require NativeModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ var Login = React.createClass({
 ##### Exhaustive
 ```js
 var FBLogin = require('react-native-facebook-login');
-var FBLoginManager = require('NativeModules').FBLoginManager;
+var { NativeModules: { FBLoginManager } }  = require('react-native');
+
 
 var Login = React.createClass({
   render: function() {
@@ -94,7 +95,7 @@ See [example/components/facebook/FBLoginMock.js](example/components/facebook/FBL
 
 ### Usage
 ```js
-var FBLoginManager = require('NativeModules').FBLoginManager;
+var { NativeModules: { FBLoginManager } }  = require('react-native');
 
 FBLoginManager.loginWithPermissions(["email","user_friends"], function(error, data){
   if (!error) {
@@ -111,7 +112,7 @@ A variety of events are emitted across the React Native bridge back to your java
 ### Usage
 ```js
 var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
-var FBLoginManager = require('NativeModules').FBLoginManager;
+var { NativeModules: { FBLoginManager } }  = require('react-native');
 
 ...
 


### PR DESCRIPTION
fixes unit testing with jest (otherwise you get `Error: Cannot find module 'NativeModules' `)

copied from here: https://github.com/smore-inc/react-native-segment-io-analytics/issues/3
````
All require statements for React Native modules should go through the public interface:
// This may pull in an unexpected version of `RCTDeviceEventEmitter` and `NativeModules`
var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
var RNKeyboardEventsManager = require('NativeModules').RNKeyboardEventsManager
becomes

// This will ensure that you require the correct modules, via the react-native package
var {
  DeviceEventEmitter,
  NativeModules: {
    RNKeyboardEventsManager,
  },
} = require('react-native');
````
https://github.com/facebook/react-native/releases/tag/v0.7.0-rc

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/magus/react-native-facebook-login/53)
<!-- Reviewable:end -->
