### PR TITLE
Addresses documentation error identified in github issue #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ $(SRCROOT)/../node_modules/react-native-facebook-login/FacebookSDK
 
 <img src="https://raw.githubusercontent.com/magus/react-native-facebook-login/master/images/fbsdkapplicationdelegate-methods-example.png" alt="example-fbsdk-frameworks" />
 
+##### Link the `libRCTFBLogin.a` file
+
+Add `libRCTFBLogin.a` to build target's Linked Frameworks and Libraries list
+
+
 ## Example project
 ### Toy
 ```sh


### PR DESCRIPTION
Issue https://github.com/magus/react-native-facebook-login/issues/26 identifies an issue with the current documentation for installing this library. This pull-request fixes that documentation problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/magus/react-native-facebook-login/62)
<!-- Reviewable:end -->
