### PR TITLE
[Android] general fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ subscriber.remove();
 ```
 
 ## Setup
-### [Android](/android/README.md)
+### [Android](/android)
 [Click here for Android setup instructions](/android/README.md)
+
 ### iOS
 ```sh
 npm install --save react-native-facebook-login

--- a/android/README.md
+++ b/android/README.md
@@ -35,7 +35,7 @@ import com.magus.fblogin.FacebookLoginPackage; // <--- import
 public class MainActivity extends ReactActivity {
 
     ...
-    
+
     @Override
     protected List<ReactPackage> getPackages() {
         return Arrays.<ReactPackage>asList(
@@ -94,13 +94,142 @@ public class MainActivity extends ReactActivity {
 ```js
 var {NativeModules} = require('react-native');
 var FBLogin = require('react-native-facebook-login');
-var FBLoginManager = NativeModules.FBLoginManager; // if needed
+var FBLoginManager = NativeModules.FBLoginManager;
 
-//eg.
+/**
+  eg.
+  Please note:
+  - if buttonView is not set then a default view will be shown
+  - this is not meant to be a full example but highlights what you have access to
+**/
 <FBLogin
+    buttonView={<FBLoginView />}
+    loginBehavior={FBLoginManager.LoginBehaviors.Native}
+    permissions={["email","user_friends"]}
     onLogin={function(e){console.log(e)}}
+    onLoginFound={function(e){console.log(e)}}
+    onLoginNotFound={function(e){console.log(e)}}
     onLogout={function(e){console.log(e)}}
     onCancel={function(e){console.log(e)}}
     onPermissionsMissing={function(e){console.log(e)}}
   />
 ```
+
+eg. FBLoginView class
+```js
+var React = require('react-native');
+var {View, Text, StyleSheet} = React;
+var Icon = require('react-native-vector-icons/FontAwesome');
+
+/**
+  Example FBLoginView class
+  Please note:
+  - this is not meant to be a full example but highlights what you have access to
+  - If you use a touchable component, you will need to set the onPress event like below
+**/
+class FBLoginView extends React.Component {
+  static contextTypes = {
+    isLoggedIn: React.PropTypes.bool,
+    login: React.PropTypes.func,
+    logout: React.PropTypes.func,
+    props: React.PropTypes.object
+	};
+
+  constructor(props) {
+      super(props);
+    }
+
+    render(){
+        return (
+          <View style={[]}>
+            <Icon.Button onPress={() => {
+                if(!this.context.isLoggedIn){
+                  this.context.login()
+                }else{
+                  this.context.logout()
+                }
+
+              }}
+              color={"#000000"}
+              backgroundColor={"#ffffff"} name={"facebook"}  size={20} borderRadius={100} >
+
+            </Icon.Button>
+          </View>
+      )
+    }
+}
+module.exports = FBLoginView;
+```
+
+### Tips
+
+#### Android version now has a `setLoginBehavior()` function
+
+You can use this to set the login behavior when not using the default button.
+It accepts a value from the enum `FBLoginManager.LoginBehaviors`
+eg.
+
+```js
+FBLoginManager.setLoginBehavior(FBLoginManager.LoginBehaviors.Native);
+```
+
+#### Login Behavior Differences
+
+LoginBehaviors enum seems to be diff from IOS so a mapping was done but there are still two differences:
+- `Browser` **(IOS only)**  [if used, this will default to **Native**]
+- `NativeOnly` **(Android only)**
+
+```js
+// android interpretation of loginBehaviors
+// these will map to the android sdk LoginBehavior enum
+FBLoginManager.LoginBehaviors = {
+   SystemAccount:"DEVICE_AUTH",
+   NativeOnly:"NATIVE_ONLY",
+   Native:"NATIVE_WITH_FALLBACK", // android default
+   Web:"WEB_ONLY"
+}
+```
+
+Given this information, some apps may still want to use different behaviors per platform.
+A simple solution you may use is as follows:
+
+```js
+//eg.
+var { Platform, NativeModules } = React;
+var FBLoginManager = NativeModules.FBLoginManager;
+var LoginBehavior = {
+  'ios': FBLoginManager.LoginBehaviors.Browser,
+  'android': FBLoginManager.LoginBehaviors.Native
+}
+
+...
+
+<FBLogin
+    loginBehavior={LoginBehavior[Platform.OS]}
+  />
+
+```
+
+#### In some cases we were getting the following error when compiling
+
+```java
+Unknown source file : UNEXPECTED TOP-LEVEL EXCEPTION:
+Unknown source file : com.android.dex.DexException: Multiple dex files define Lbolts/AggregateException;
+```
+This happens because Gradle is trying to load two versions of bolts.
+
+Current Solution that works:
+
+We are excluding bolts from the FB SDK in order to avoid this collision
+
+```gradle
+compile ('com.facebook.android:facebook-android-sdk:4.10.+'){
+        exclude group: 'com.parse.bolts', module: 'bolts-android';
+        exclude group: 'com.parse.bolts', module: 'bolts-applinks';
+        exclude group: 'com.parse.bolts', module: 'bolts-tasks';
+    }
+```
+
+If this gives issues in the future, please report an issue.
+
+Thanks.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,10 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.18.+'
-    compile 'com.facebook.android:facebook-android-sdk:4.6.0'
+    compile 'com.facebook.react:react-native:+'
+    compile ('com.facebook.android:facebook-android-sdk:4.10.+'){
+        exclude group: 'com.parse.bolts', module: 'bolts-android';
+        exclude group: 'com.parse.bolts', module: 'bolts-applinks';
+        exclude group: 'com.parse.bolts', module: 'bolts-tasks';
+    }
 }

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,0 +1,7 @@
+var service = {}
+
+service.itypeof = function (val) {
+    return Object.prototype.toString.call(val).replace(/(\[|object|\s|\])/g, '').toLowerCase();
+};
+
+module.exports = service;


### PR DESCRIPTION
updated docs: https://github.com/lwhiteley/react-native-facebook-login/tree/master/android

### Changeset:
- adding feature for setting login behavior for android
- `onLoginFound` and `onLoginNotFound` events were added
- add `buttonView` Property to override default view

#### Breaking changes:
- `getCurrentToken` has been changed to `getCredentials`
- `getCredentials` returns an object instead of a string
- returned data object now has `credentials` sub object that has token information similar to IOS version
- remove enforcement of email permission, permissions must be passed in button now


A couple caveats currently: 

LoginBehaviors enum seems to be diff from IOS
Mapping was done but there are still two diferrences : 
- android has no Browser behavior **(IOS does)**  [if used, this will default to **Native**]
- android has a NativeOnly behavior **(IOS doesn't)**
```js
// android interpretation of loginBehaviors
// these will map to the android sdk LoginBehavior enum
FBLoginManager.LoginBehaviors = {
   SystemAccount:"DEVICE_AUTH"
   NativeOnly:"NATIVE_ONLY"
   Native:"NATIVE_WITH_FALLBACK"
   Web:"WEB_ONLY"
}
```

Should resolve/partially address the following issues:
#103  (**Partially addressed, IOS doesn't have this**) [Tested]
#81  [Tested]
#55  [Tested]
#86  [Tested]
#77  [Tested]
#91  [Tested]
#100  [Tested]
#73  [Tested]

if testing, please ensure to be aware of breaking changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/magus/react-native-facebook-login/105)
<!-- Reviewable:end -->