### PR TITLE
Updated imports to support RN 0.26

### DIFF
--- a/example/components/Login.js
+++ b/example/components/Login.js
@@ -1,11 +1,13 @@
 'use strict';
+var React = require('react');
+var ReactNative = require('react-native');
 
 var {
   StyleSheet,
   Image,
   Text,
   View,
-} = React;
+} = ReactNative;
 
 var FBLogin = require('react-native-facebook-login');
 var FBLoginMock = require('./facebook/FBLoginMock.js');

--- a/example/components/LoginMock.js
+++ b/example/components/LoginMock.js
@@ -1,11 +1,13 @@
 'use strict';
+var React = require('react');
+var ReactNative = require('react-native');
 
 var {
   StyleSheet,
   Image,
   Text,
   View,
-} = React;
+} = ReactNative;
 
 var FBLoginMock = require('./facebook/FBLoginMock.js');
 var FBLoginManager = require('NativeModules').FBLoginManager;

--- a/example/components/facebook/FBLoginMock.js
+++ b/example/components/facebook/FBLoginMock.js
@@ -1,4 +1,6 @@
 'use strict';
+var React = require('react');
+var ReactNative = require('react-native');
 
 var {
   StyleSheet,
@@ -6,7 +8,7 @@ var {
   Image,
   View,
   TouchableHighlight,
-} = React;
+} = ReactNative;
 
 var FBLoginManager = require('NativeModules').FBLoginManager;
 

--- a/example/index.ios.js
+++ b/example/index.ios.js
@@ -1,4 +1,5 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 
 // Make react global
 window.React = React;
@@ -7,7 +8,7 @@ var {
   AppRegistry,
   NavigatorIOS,
   StyleSheet,
-} = React;
+} = ReactNative;
 
 var Login = require('./components/Login');
 var LoginMock = require('./components/LoginMock');

--- a/index.android.js
+++ b/index.android.js
@@ -1,11 +1,13 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
+
 var {
   NativeModules,
   StyleSheet,
   View,
   TouchableHighlight,
   Text
-} = React;
+} = ReactNative;
 
 var FBLoginManager = NativeModules.FBLoginManager;
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,13 +1,18 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
+
+var {
+    PropTypes,
+} = React;
+
 var {
   View,
   StyleSheet,
-  PropTypes,
   NativeModules,
   requireNativeComponent,
   NativeMethodsMixin,
   DeviceEventEmitter,
-} = React;
+} = ReactNative;
 
 var { FBLoginManager } = NativeModules;
 
@@ -54,7 +59,7 @@ var FBLogin = React.createClass({
           eventHandler && eventHandler(eventData);
         }
       ));
-    })
+    });
 
     // Add listeners to state
     this.setState({ subscriptions : subscriptions });


### PR DESCRIPTION
Requiring React API from react-native will stop working in 0.26 and raises a warning in 0.25.

See release notes for 0.25.1: https://github.com/facebook/react-native/releases/tag/v0.25.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/magus/react-native-facebook-login/117)
<!-- Reviewable:end -->
