### PR TITLE
Enable FBLoginManager.loginBehavior for iOS as well

### DIFF
--- a/RCTFBLogin/RCTFBLoginManager.m
+++ b/RCTFBLogin/RCTFBLoginManager.m
@@ -11,6 +11,7 @@
 {
   RCTFBLogin *_fbLogin;
   NSArray *_defaultPermissions;
+  NSNumber *_loginBehavior;
 }
 
 @synthesize bridge = _bridge;
@@ -19,8 +20,10 @@
 {
   _fbLogin = [[RCTFBLogin alloc] init];
   _defaultPermissions = @[@"email"];
+  _loginBehavior = FBSDKLoginBehaviorNative;
 
   [_fbLogin setPermissions:_defaultPermissions];
+  [_fbLogin setLoginBehavior:_loginBehavior];
   [_fbLogin setDelegate:self];
   return _fbLogin;
 }
@@ -164,6 +167,7 @@ RCT_EXPORT_METHOD(loginWithPermissions:(NSArray *)permissions callback:(RCTRespo
 
   // No existing access token or missing permissions
   FBSDKLoginManager *login = [[FBSDKLoginManager alloc] init];
+  login.loginBehavior = [_loginBehavior unsignedIntValue];
   [login logInWithReadPermissions:permissions fromViewController:nil handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
     if (error) {
       [self fireEvent:@"Error" withData:@{
@@ -218,6 +222,10 @@ RCT_EXPORT_METHOD(getCredentials:(RCTResponseSenderBlock)callback) {
     [self fireEvent:@"LoginNotFound"];
     callback(@[@"LoginNotFound", [NSNull null]]);
   }
+}
+
+RCT_EXPORT_METHOD(setLoginBehavior:(NSNumber * _Nonnull)loginBehavior) {
+  _loginBehavior = loginBehavior;
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ See [example/components/facebook/FBLoginMock.js](example/components/facebook/FBL
 ```js
 var {FBLoginManager} = require('react-native-facebook-login');
 
+FBLoginManager.setLoginBehavior(FBLoginManager.LoginBehaviors.Web); // defaults to Native
+
 FBLoginManager.loginWithPermissions(["email","user_friends"], function(error, data){
   if (!error) {
     console.log("Login data: ", data);


### PR DESCRIPTION
Hi, in android you have setLoginBehavior method on FBLoginManager - I enabled this for iOS as well...
What do you think, could you please pull these changes?

Otherwise your lib is awesome, really simplifies all the facebook sdk hassle, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/magus/react-native-facebook-login/130)
<!-- Reviewable:end -->
