### PR TITLE
Fix PropTypes warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Provides a React Native component which wraps the Facebook SDK `FBSDKLoginButton
 
 ##### Defaults
 ```js
-import React, { PropTypes, Component } from 'react';
-var {FBLogin, FBLoginManager} = require('react-native-facebook-login');
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+var { FBLogin, FBLoginManager } = require('react-native-facebook-login');
 
 class Login extends Component {
   render() {
@@ -35,8 +36,9 @@ class Login extends Component {
 
 ##### Exhaustive
 ```js
-import React, { PropTypes, Component } from 'react';
-var {FBLogin, FBLoginManager} = require('react-native-facebook-login');
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+var { FBLogin, FBLoginManager } = require('react-native-facebook-login');
 
 class Login extends Component {
   render() {

--- a/android/README.md
+++ b/android/README.md
@@ -134,7 +134,8 @@ import {FBLogin, FBLoginManager} from 'react-native-facebook-login';
 eg. FBLoginView class
 ```js
 import React, { Component } from 'react';
-import { StyleSheet,Text,View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import PropTypes from 'prop-types';
 var Icon = require('react-native-vector-icons/FontAwesome');
 
 /**
@@ -145,10 +146,10 @@ var Icon = require('react-native-vector-icons/FontAwesome');
 **/
 class FBLoginView extends Component {
   static contextTypes = {
-    isLoggedIn: React.PropTypes.bool,
-    login: React.PropTypes.func,
-    logout: React.PropTypes.func,
-    props: React.PropTypes.object
+    isLoggedIn: PropTypes.bool,
+    login: PropTypes.func,
+    logout: PropTypes.func,
+    props: PropTypes.shape({})
 	};
 
   constructor(props) {

--- a/example/components/Login.js
+++ b/example/components/Login.js
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var ReactNative = require('react-native');
+var PropTypes = require('prop-types');
 
 var {
   StyleSheet,
@@ -72,7 +73,7 @@ var Login = React.createClass({
 
 var Photo = React.createClass({
   propTypes: {
-    user: React.PropTypes.object.isRequired,
+    user: PropTypes.shape({}).isRequired,
   },
 
   getInitialState: function(){
@@ -131,7 +132,7 @@ var Photo = React.createClass({
 
 var Info = React.createClass({
   propTypes: {
-    user: React.PropTypes.object.isRequired,
+    user: PropTypes.shape({}).isRequired,
   },
 
   getInitialState: function(){

--- a/example/components/LoginMock.js
+++ b/example/components/LoginMock.js
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var ReactNative = require('react-native');
+var PropTypes = require('prop-types');
 
 var {
   StyleSheet,
@@ -68,7 +69,7 @@ var Login = React.createClass({
 
 var Photo = React.createClass({
   propTypes: {
-    user: React.PropTypes.object.isRequired,
+    user: PropTypes.shape({}).isRequired,
   },
 
   getInitialState: function(){
@@ -118,7 +119,7 @@ var Photo = React.createClass({
 
 var Info = React.createClass({
   propTypes: {
-    user: React.PropTypes.object.isRequired,
+    user: PropTypes.shape({}).isRequired,
   },
 
   getInitialState: function(){

--- a/example/components/facebook/FBLoginMock.js
+++ b/example/components/facebook/FBLoginMock.js
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var ReactNative = require('react-native');
+var PropTypes = require('prop-types');
 
 var {
   StyleSheet,
@@ -15,9 +16,9 @@ var FBLoginManager = require('NativeModules').FBLoginManager;
 var FBLoginMock = React.createClass({
   propTypes: {
     style: View.propTypes.style,
-    onPress: React.PropTypes.func,
-    onLogin: React.PropTypes.func,
-    onLogout: React.PropTypes.func,
+    onPress: PropTypes.func,
+    onLogin: PropTypes.func,
+    onLogout: PropTypes.func,
   },
 
   getInitialState: function(){

--- a/example/package.json
+++ b/example/package.json
@@ -6,6 +6,7 @@
     "start": "node_modules/react-native/packager/packager.sh --assetRoots=./iOS/Images.xcassets"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react-native": ">=0.18.1",
     "react-native-facebook-login": "file:../"
   }

--- a/index.android.js
+++ b/index.android.js
@@ -1,7 +1,5 @@
-import React, {
-  PropTypes,
-  Component
-} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   View,
@@ -72,7 +70,7 @@ class FBLogin extends Component {
     isLoggedIn: PropTypes.bool,
     login: PropTypes.func,
     logout: PropTypes.func,
-    props: PropTypes.object
+    props: PropTypes.shape({})
   }
 
   getChildContext () {

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,7 +1,5 @@
-import React, {
-  PropTypes,
-  Component
-}from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   View,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/magus/react-native-facebook-login",
   "peerDependencies": {
     "react-native": ">=0.26.2",
-    "react": ">=15.0.2"
+    "react": ">=15.0.2",
+    "prop-types": "^15.5.10"
   },
   "dependencies": {
     "itypeof": "^1.1.2"


### PR DESCRIPTION
Use prop-types npm module. React.PropTypes will be removed completely in React 16.