### PR TITLE
Removed override notation of deprecated method (createJSModules) of React Native 0.47.0

### DIFF
--- a/android/src/main/java/com/magus/fblogin/FacebookLoginPackage.java
+++ b/android/src/main/java/com/magus/fblogin/FacebookLoginPackage.java
@@ -17,7 +17,7 @@ public class FacebookLoginPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new FacebookLoginModule(reactContext));
     }
 
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Hi,

Due to https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8 's breaking change, we should remove the override notation of deprecated method `createJSModules`.

Thank you.
