### PR TITLE
Updating link for iOS Facebook SDK Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ npm install --save react-native-facebook-login
 **Note**: If your build fails, you most likely forgot to setup the [Facebook SDK](#facebook-sdk)
 
 #### Facebook SDK
-[Facebook : Quick Start for iOS](https://developers.facebook.com/quickstarts/?platform=ios)
+[Facebook : Quick Start for iOS](https://developers.facebook.com/docs/ios/getting-started#sdk-project)
 
 Be sure to [configure your .plist file](https://developers.facebook.com/docs/ios/getting-started#xcode). This file is located under the `ios/<project-name>` directory of your generated react-native project. It should be in the same folder as your `AppDelegate.m` file.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ npm install --save react-native-facebook-login
 **Note**: If your build fails, you most likely forgot to setup the [Facebook SDK](#facebook-sdk)
 
 #### Facebook SDK
-[Facebook : Quick Start for iOS](https://developers.facebook.com/docs/ios/getting-started#sdk-project)
+[Facebook : Quick Start for iOS](https://developers.facebook.com/docs/facebook-login/ios)
 
 Be sure to [configure your .plist file](https://developers.facebook.com/docs/ios/getting-started#xcode). This file is located under the `ios/<project-name>` directory of your generated react-native project. It should be in the same folder as your `AppDelegate.m` file.
 


### PR DESCRIPTION
The updated link is not behind a login and lands directly on the pertinent section.