### PR TITLE
View.propTypes has been deprecated

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import {
   View,
+  ViewPropTypes,
   StyleSheet,
   NativeModules,
   NativeMethodsMixin,
@@ -90,7 +91,7 @@ class FBLogin extends Component {
 }
 
 FBLogin.propTypes = {
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   permissions: PropTypes.array, // default: ["public_profile", "email"]
   loginBehavior: PropTypes.number, // default: Native
   onLogin: PropTypes.func,


### PR DESCRIPTION
Use ViewPropTypes instead.

View.propTypes is intended for DEV mode.
So, when I'm using this awesome library, in DEV mode it works perfectly fine, but as soon as I build the release version, it crashes.

Using react-native 0.50.0 with react 16.0.0.

More info here:
https://github.com/react-community/react-navigation/issues/1352
https://github.com/facebook/react-native/issues/16352